### PR TITLE
fixed composer version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation
 
 Make sure you have [composer][3] installed, and then run:
 
-    composer require sabre/event ~2.0.0
+    composer require sabre/event "~2.0.0"
 
 Build status
 ------------


### PR DESCRIPTION
prevents "Could not parse version constraint : Invalid version string" error (maybe only happens on windows, did not test on linux/mac)
