### PR TITLE
Fix typos in doc comments

### DIFF
--- a/lib/EmitterInterface.php
+++ b/lib/EmitterInterface.php
@@ -31,7 +31,7 @@ interface EmitterInterface {
     /**
      * Emits an event.
      *
-     * This method will return true if 0 or more listeners were succesfully
+     * This method will return true if 0 or more listeners were successfully
      * handled. false is returned if one of the events broke the event chain.
      *
      * If the continueCallBack is specified, this callback will be called every

--- a/lib/EmitterTrait.php
+++ b/lib/EmitterTrait.php
@@ -61,7 +61,7 @@ trait EmitterTrait {
     /**
      * Emits an event.
      *
-     * This method will return true if 0 or more listeners were succesfully
+     * This method will return true if 0 or more listeners were successfully
      * handled. false is returned if one of the events broke the event chain.
      *
      * If the continueCallBack is specified, this callback will be called every

--- a/lib/Loop/Loop.php
+++ b/lib/Loop/Loop.php
@@ -180,7 +180,7 @@ class Loop {
     /**
      * Runs the loop.
      *
-     * This function will run continiously, until there's no more events to
+     * This function will run continuously, until there's no more events to
      * handle.
      *
      * @return void

--- a/lib/Loop/functions.php
+++ b/lib/Loop/functions.php
@@ -112,7 +112,7 @@ function removeWriteStream($stream) {
 /**
  * Runs the loop.
  *
- * This function will run continiously, until there's no more events to
+ * This function will run continuously, until there's no more events to
  * handle.
  *
  * @return void

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -103,7 +103,7 @@ class Promise {
                 $this->invokeCallback($subPromise, $onFulfilled);
                 break;
             case self::REJECTED :
-                // The async operation failed, so we call teh onRejected
+                // The async operation failed, so we call the onRejected
                 // callback asap.
                 $this->invokeCallback($subPromise, $onRejected);
                 break;
@@ -161,7 +161,7 @@ class Promise {
     /**
      * Stops execution until this promise is resolved.
      *
-     * This method stops exection completely. If the promise is successful with
+     * This method stops execution completely. If the promise is successful with
      * a value, this method will return this value. If the promise was
      * rejected, this method will throw an exception.
      *

--- a/lib/Promise/functions.php
+++ b/lib/Promise/functions.php
@@ -24,7 +24,7 @@ use Throwable;
  *
  * This array will be in the exact same order as the array of input promises.
  *
- * If any of the given Promises fails, the returned promise will immidiately
+ * If any of the given Promises fails, the returned promise will immediately
  * fail with the first Promise that fails, and its reason.
  *
  * @param Promise[] $promises

--- a/lib/WildcardEmitterTrait.php
+++ b/lib/WildcardEmitterTrait.php
@@ -26,7 +26,7 @@ trait WildcardEmitterTrait {
      */
     function on(string $eventName, callable $callBack, int $priority = 100) {
 
-        // If it ends with a wildcard, we use the wildcardListeners array 
+        // If it ends with a wildcard, we use the wildcardListeners array
         if ($eventName[\strlen($eventName) - 1] === '*') {
             $eventName = \substr($eventName, 0, -1);
             $listeners = & $this->wildcardListeners;
@@ -69,7 +69,7 @@ trait WildcardEmitterTrait {
     /**
      * Emits an event.
      *
-     * This method will return true if 0 or more listeners were succesfully
+     * This method will return true if 0 or more listeners were successfully
      * handled. false is returned if one of the events broke the event chain.
      *
      * If the continueCallBack is specified, this callback will be called every
@@ -183,7 +183,7 @@ trait WildcardEmitterTrait {
      */
     function removeListener(string $eventName, callable $listener) : bool {
 
-        // If it ends with a wildcard, we use the wildcardListeners array 
+        // If it ends with a wildcard, we use the wildcardListeners array
         if ($eventName[\strlen($eventName) - 1] === '*') {
             $eventName = \substr($eventName, 0, -1);
             $listeners = & $this->wildcardListeners;
@@ -250,7 +250,7 @@ trait WildcardEmitterTrait {
     protected $listeners = [];
 
     /**
-     * The list of "wildcard listeners". 
+     * The list of "wildcard listeners".
      */
     protected $wildcardListeners = [];
 


### PR DESCRIPTION
Detected by https://github.com/client9/misspell

Also, remove trailing whitespace from files that had typos.