### PR TITLE
Increase phpstan to level 7

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 6
+  level: 7
   phpVersion: 70430 # PHP 7.4.30
   ignoreErrors:
   -

--- a/tests/Event/Loop/FunctionsTest.php
+++ b/tests/Event/Loop/FunctionsTest.php
@@ -78,6 +78,9 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function testAddWriteStream(): void
     {
         $h = fopen('php://temp', 'r+');
+        if (false === $h) {
+            $this->fail('failed to open php://temp');
+        }
         addWriteStream($h, function () use ($h) {
             fwrite($h, 'hello world');
             removeWriteStream($h);
@@ -90,6 +93,9 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function testAddReadStream(): void
     {
         $h = fopen('php://temp', 'r+');
+        if (false === $h) {
+            $this->fail('failed to open php://temp');
+        }
         fwrite($h, 'hello world');
         rewind($h);
 

--- a/tests/Event/Loop/LoopTest.php
+++ b/tests/Event/Loop/LoopTest.php
@@ -70,6 +70,9 @@ class LoopTest extends \PHPUnit\Framework\TestCase
     public function testAddWriteStream(): void
     {
         $h = fopen('php://temp', 'r+');
+        if (false === $h) {
+            $this->fail('failed to open php://temp');
+        }
         $loop = new Loop();
         $loop->addWriteStream($h, function () use ($h, $loop) {
             fwrite($h, 'hello world');
@@ -83,6 +86,9 @@ class LoopTest extends \PHPUnit\Framework\TestCase
     public function testAddReadStream(): void
     {
         $h = fopen('php://temp', 'r+');
+        if (false === $h) {
+            $this->fail('failed to open php://temp');
+        }
         fwrite($h, 'hello world');
         rewind($h);
 


### PR DESCRIPTION
```
------ ------------------------------------------------------------------------------------------------------------- 
  Line   tests/Event/Loop/FunctionsTest.php                                                                           
 ------ ------------------------------------------------------------------------------------------------------------- 
  81     Parameter #1 $stream of function Sabre\Event\Loop\addWriteStream expects resource, resource|false given.     
  82     Parameter #1 $fp of function fwrite expects resource, resource|false given.                                  
  83     Parameter #1 $stream of function Sabre\Event\Loop\removeWriteStream expects resource, resource|false given.  
  86     Parameter #1 $fp of function rewind expects resource, resource|false given.                                  
  87     Parameter #1 $source of function stream_get_contents expects resource, resource|false given.                 
 ------ ------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------- 
  Line   tests/Event/Loop/LoopTest.php                                                                                      
 ------ ------------------------------------------------------------------------------------------------------------------- 
  74     Parameter #1 $stream of method Sabre\Event\Loop\Loop::addWriteStream() expects resource, resource|false given.     
  75     Parameter #1 $fp of function fwrite expects resource, resource|false given.                                        
  76     Parameter #1 $stream of method Sabre\Event\Loop\Loop::removeWriteStream() expects resource, resource|false given.  
  79     Parameter #1 $fp of function rewind expects resource, resource|false given.                                        
  80     Parameter #1 $source of function stream_get_contents expects resource, resource|false given.                       
  86     Parameter #1 $fp of function fwrite expects resource, resource|false given.                                        
  87     Parameter #1 $fp of function rewind expects resource, resource|false given.                                        
  93     Parameter #1 $stream of method Sabre\Event\Loop\Loop::addReadStream() expects resource, resource|false given.      
  94     Parameter #1 $fp of function fgets expects resource, resource|false given.                                         
  95     Parameter #1 $stream of method Sabre\Event\Loop\Loop::removeReadStream() expects resource, resource|false given.   
 ------ ------------------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 15 errors                                                                                                
                                                                                                                        
```

phpstan only finds small things in test code. They are easily fixed - just check if the `fopen` calls happened to fail.

No changes needed to real code.