### PR TITLE
Increase phpstan to level 8

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 7
+  level: 8
   phpVersion: 70430 # PHP 7.4.30
   ignoreErrors:
   -

--- a/tests/Event/Loop/FunctionsTest.php
+++ b/tests/Event/Loop/FunctionsTest.php
@@ -67,6 +67,9 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
         $intervalId = setInterval(function () use (&$check, &$intervalId) {
             ++$check;
             if ($check > 5) {
+                if (null === $intervalId) {
+                    throw new \Exception('intervalId is not set - cannot clearInterval');
+                }
                 clearInterval($intervalId);
             }
         }, 0.02);

--- a/tests/Event/Loop/LoopTest.php
+++ b/tests/Event/Loop/LoopTest.php
@@ -59,6 +59,9 @@ class LoopTest extends \PHPUnit\Framework\TestCase
         $intervalId = $loop->setInterval(function () use (&$check, &$intervalId, $loop) {
             ++$check;
             if ($check > 5) {
+                if (null === $intervalId) {
+                    throw new \Exception('intervalId is not set - cannot clearInterval');
+                }
                 $loop->clearInterval($intervalId);
             }
         }, 0.02);


### PR DESCRIPTION
```
------ ------------------------------------------------------------------------------------------------------------------------------ 
  Line   tests/Event/Loop/FunctionsTest.php                                                                                            
 ------ ------------------------------------------------------------------------------------------------------------------------------ 
  70     Parameter #1 $intervalId of function Sabre\Event\Loop\clearInterval expects array<int, mixed>, array<int, mixed>|null given.  
 ------ ------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------------------------ 
  Line   tests/Event/Loop/LoopTest.php                                                                                                       
 ------ ------------------------------------------------------------------------------------------------------------------------------------ 
  62     Parameter #1 $intervalId of method Sabre\Event\Loop\Loop::clearInterval() expects array<int, mixed>, array<int, mixed>|null given.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------ 
```

It only found these things in test code - no real code needs to be changed.

Fix the callback functions defined in the tests by having them check in case `$intervalId` is still `null` and throw an exception.