### PR TITLE
Adjust code style to meet current php-cs-fixer

### DIFF
--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Event;
 
-use Throwable;
-
 /**
  * An implementation of the Promise pattern.
  *
@@ -147,7 +145,7 @@ class Promise
     /**
      * Marks this promise as rejected, and set its rejection reason.
      */
-    public function reject(Throwable $reason): void
+    public function reject(\Throwable $reason): void
     {
         if (self::PENDING !== $this->state) {
             throw new PromiseAlreadyResolvedException('This promise is already resolved, and you\'re not allowed to resolve a promise more than once');
@@ -246,7 +244,7 @@ class Promise
                         // immediately fulfill the chained promise.
                         $subPromise->fulfill($result);
                     }
-                } catch (Throwable $e) {
+                } catch (\Throwable $e) {
                     // If the event handler threw an exception, we need to make sure that
                     // the chained promise is rejected as well.
                     $subPromise->reject($e);

--- a/lib/Promise/functions.php
+++ b/lib/Promise/functions.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sabre\Event\Promise;
 
 use Sabre\Event\Promise;
-use Throwable;
 
 /**
  * This file contains a set of functions that are useful for dealing with the
@@ -127,7 +126,7 @@ function resolve($value): Promise
  *
  * @return Promise<mixed>
  */
-function reject(Throwable $reason): Promise
+function reject(\Throwable $reason): Promise
 {
     $promise = new Promise();
     $promise->reject($reason);

--- a/lib/coroutine.php
+++ b/lib/coroutine.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sabre\Event;
 
 use Generator;
-use Throwable;
 
 /**
  * Turn asynchronous promise-based code into something that looks synchronous
@@ -55,7 +54,7 @@ use Throwable;
 function coroutine(callable $gen): Promise
 {
     $generator = $gen();
-    if (!$generator instanceof Generator) {
+    if (!$generator instanceof \Generator) {
         throw new \InvalidArgumentException('You must pass a generator function');
     }
 
@@ -75,11 +74,11 @@ function coroutine(callable $gen): Promise
                         $generator->send($value);
                         $advanceGenerator();
                     },
-                    function (Throwable $reason) use ($generator, $advanceGenerator) {
+                    function (\Throwable $reason) use ($generator, $advanceGenerator) {
                         $generator->throw($reason);
                         $advanceGenerator();
                     }
-                )->otherwise(function (Throwable $reason) use ($promise) {
+                )->otherwise(function (\Throwable $reason) use ($promise) {
                     // This error handler would be called, if something in the
                     // generator throws an exception, and it's not caught
                     // locally.
@@ -104,7 +103,7 @@ function coroutine(callable $gen): Promise
             if ($returnValue instanceof Promise) {
                 $returnValue->then(function ($value) use ($promise) {
                     $promise->fulfill($value);
-                }, function (Throwable $reason) use ($promise) {
+                }, function (\Throwable $reason) use ($promise) {
                     $promise->reject($reason);
                 });
             } else {
@@ -115,7 +114,7 @@ function coroutine(callable $gen): Promise
 
     try {
         $advanceGenerator();
-    } catch (Throwable $e) {
+    } catch (\Throwable $e) {
         $promise->reject($e);
     }
 

--- a/tests/Event/CoroutineTest.php
+++ b/tests/Event/CoroutineTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Event;
 
-use Exception;
-
 class CoroutineTest extends \PHPUnit\Framework\TestCase
 {
     public function testNonGenerator(): void
@@ -46,7 +44,7 @@ class CoroutineTest extends \PHPUnit\Framework\TestCase
     {
         $start = 0;
         $promise = new Promise(function ($fulfill, $reject) {
-            $reject(new Exception('2'));
+            $reject(new \Exception('2'));
         });
 
         coroutine(function () use (&$start, $promise) {

--- a/tests/Event/Promise/FunctionsTest.php
+++ b/tests/Event/Promise/FunctionsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Event\Promise;
 
-use Exception;
 use Sabre\Event\Loop;
 use Sabre\Event\Promise;
 
@@ -53,10 +52,10 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
             }
         );
 
-        $promise1->reject(new Exception('1'));
+        $promise1->reject(new \Exception('1'));
         Loop\run();
         $this->assertEquals('1', $finalValue->getMessage());
-        $promise2->reject(new Exception('2'));
+        $promise2->reject(new \Exception('2'));
         Loop\run();
         $this->assertEquals(1, $finalValue->getMessage());
     }
@@ -78,10 +77,10 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
             }
         );
 
-        $promise1->reject(new Exception('1'));
+        $promise1->reject(new \Exception('1'));
         Loop\run();
         $this->assertEquals(1, $finalValue->getMessage());
-        $promise2->fulfill(new Exception('2'));
+        $promise2->fulfill(new \Exception('2'));
         Loop\run();
         $this->assertEquals(1, $finalValue->getMessage());
     }
@@ -124,10 +123,10 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
             }
         );
 
-        $promise1->reject(new Exception('1'));
+        $promise1->reject(new \Exception('1'));
         Loop\run();
         $this->assertEquals(1, $finalValue->getMessage());
-        $promise2->reject(new Exception('2'));
+        $promise2->reject(new \Exception('2'));
         Loop\run();
         $this->assertEquals(1, $finalValue->getMessage());
     }
@@ -162,7 +161,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     {
         $finalValue = 0;
 
-        $promise = reject(new Exception('1'));
+        $promise = reject(new \Exception('1'));
         $promise->then(function ($value) use (&$finalValue) {
             $finalValue = 'im broken';
         }, function ($reason) use (&$finalValue) {

--- a/tests/Event/Promise/PromiseTest.php
+++ b/tests/Event/Promise/PromiseTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Event\Promise;
 
-use Exception;
 use Sabre\Event\Loop;
 use Sabre\Event\Promise;
 use Sabre\Event\PromiseAlreadyResolvedException;
@@ -29,7 +28,7 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
     {
         $finalValue = 0;
         $promise = new Promise();
-        $promise->reject(new Exception('1'));
+        $promise->reject(new \Exception('1'));
 
         $promise->then(null, function ($value) use (&$finalValue) {
             $finalValue = $value->getMessage() + 2;
@@ -105,7 +104,7 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
             $finalValue = $value->getMessage() + 2;
         });
 
-        $promise->reject(new Exception('4'));
+        $promise->reject(new \Exception('4'));
         Loop\run();
 
         $this->assertEquals(6, $finalValue);
@@ -126,7 +125,7 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
     public function testExecutorFail(): void
     {
         $promise = (new Promise(function ($success, $fail) {
-            $fail(new Exception('hi'));
+            $fail(new \Exception('hi'));
         }))->then(function ($result) use (&$realResult) {
             $realResult = 'incorrect';
         })->otherwise(function ($reason) use (&$realResult) {
@@ -149,8 +148,8 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(PromiseAlreadyResolvedException::class);
         $promise = new Promise();
-        $promise->reject(new Exception('1'));
-        $promise->reject(new Exception('1'));
+        $promise->reject(new \Exception('1'));
+        $promise->reject(new \Exception('1'));
     }
 
     public function testFromFailureHandler(): void
@@ -167,7 +166,7 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
         });
 
         $this->assertEquals(0, $ok);
-        $promise->reject(new Exception('foo'));
+        $promise->reject(new \Exception('foo'));
         Loop\run();
 
         $this->assertEquals(1, $ok);
@@ -211,7 +210,7 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
     {
         $promise = new Promise();
         Loop\nextTick(function () use ($promise) {
-            $promise->reject(new Exception('foo'));
+            $promise->reject(new \Exception('foo'));
         });
         try {
             $promise->wait();


### PR DESCRIPTION
php-cs-fixer is reporting these. I guess there has been a newer php-cs-fixer version released that is different.

It wants "root" classes and functions to use the leading `\` - `\DateTime`.

We could change some php-cs-fixer rule settings, but actually it is easy to accept these code-style changes.