### PR TITLE
Apply latest cs-fixer changes

### DIFF
--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -127,8 +127,6 @@ class Promise
 
     /**
      * Marks this promise as fulfilled and sets its return value.
-     *
-     * @param mixed $value
      */
     public function fulfill($value = null): void
     {
@@ -168,8 +166,6 @@ class Promise
      * one. In PHP it might be useful to call this on the last promise in a
      * chain.
      *
-     * @return mixed
-     *
      * @psalm-return TReturn
      */
     public function wait()
@@ -208,10 +204,8 @@ class Promise
      *
      * If the promise was fulfilled, this will be the result value. If the
      * promise was rejected, this property hold the rejection reason.
-     *
-     * @var mixed
      */
-    protected $value = null;
+    protected $value;
 
     /**
      * This method is used to call either an onFulfilled or onRejected callback.

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -127,6 +127,8 @@ class Promise
 
     /**
      * Marks this promise as fulfilled and sets its return value.
+     *
+     * @param mixed $value the value to return for the fulfilled promise
      */
     public function fulfill($value = null): void
     {
@@ -203,7 +205,9 @@ class Promise
      * The result of the promise.
      *
      * If the promise was fulfilled, this will be the result value. If the
-     * promise was rejected, this property hold the rejection reason.
+     * promise was rejected, this property holds the rejection reason.
+     *
+     * @var mixed the result to be returned when the promise is resolved
      */
     protected $value;
 

--- a/lib/Promise/functions.php
+++ b/lib/Promise/functions.php
@@ -105,6 +105,8 @@ function race(array $promises): Promise
  * If the value is a promise, the returned promise will attach itself to that
  * promise and eventually get the same state as the followed promise.
  *
+ * @param mixed $value the value to return when the promise is resolved
+ *
  * @return Promise<mixed>
  */
 function resolve($value): Promise

--- a/lib/Promise/functions.php
+++ b/lib/Promise/functions.php
@@ -105,8 +105,6 @@ function race(array $promises): Promise
  * If the value is a promise, the returned promise will attach itself to that
  * promise and eventually get the same state as the followed promise.
  *
- * @param mixed $value
- *
  * @return Promise<mixed>
  */
 function resolve($value): Promise


### PR DESCRIPTION
The latest cs-fixer does not like having "useless" PHP doc that declares a var or param to be `mixed`.
But `phpstan` complains when the param has no type declaration.

The workaround is to keep the `mixed` PHPdoc declarations, and add some text description to them. That makes cs-fixer think that they are not useless.

It's a bit annoying having to do this, but it is not completely stupid and does get both tools to pass.