### PR TITLE
chore: use php-cs-fixer 3.51

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.49",
+        "friendsofphp/php-cs-fixer": "^3.51",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.38",
+        "friendsofphp/php-cs-fixer": "^3.49",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",

--- a/lib/EmitterInterface.php
+++ b/lib/EmitterInterface.php
@@ -50,7 +50,7 @@ interface EmitterInterface
      * @param list<mixed>          $arguments
      * @param callable():bool|null $continueCallBack
      */
-    public function emit(string $eventName, array $arguments = [], callable $continueCallBack = null): bool;
+    public function emit(string $eventName, array $arguments = [], ?callable $continueCallBack = null): bool;
 
     /**
      * Returns the list of listeners for an event.
@@ -77,5 +77,5 @@ interface EmitterInterface
      * removed. If it is not specified, every listener for every event is
      * removed.
      */
-    public function removeAllListeners(string $eventName = null): void;
+    public function removeAllListeners(?string $eventName = null): void;
 }

--- a/lib/EmitterTrait.php
+++ b/lib/EmitterTrait.php
@@ -73,7 +73,7 @@ trait EmitterTrait
      * Lastly, if there are 5 event handlers for an event. The continueCallback
      * will be called at most 4 times.
      */
-    public function emit(string $eventName, array $arguments = [], callable $continueCallBack = null): bool
+    public function emit(string $eventName, array $arguments = [], ?callable $continueCallBack = null): bool
     {
         if (\is_null($continueCallBack)) {
             foreach ($this->listeners($eventName) as $listener) {
@@ -160,7 +160,7 @@ trait EmitterTrait
      * removed. If it is not specified, every listener for every event is
      * removed.
      */
-    public function removeAllListeners(string $eventName = null): void
+    public function removeAllListeners(?string $eventName = null): void
     {
         if (!\is_null($eventName)) {
             unset($this->listeners[$eventName]);
@@ -172,7 +172,7 @@ trait EmitterTrait
     /**
      * The list of listeners.
      *
-     * @var array<string, array{0:boolean, 1:list<mixed>, 2:list<callable>}>
+     * @var array<string, array{0:bool, 1:list<mixed>, 2:list<callable>}>
      */
     protected array $listeners = [];
 }

--- a/lib/Loop/Loop.php
+++ b/lib/Loop/Loop.php
@@ -61,7 +61,7 @@ class Loop
      * The value this function returns can be used to stop the interval with
      * clearInterval.
      *
-     * @return array{0:string, 1:boolean}
+     * @return array{0:string, 1:bool}
      */
     public function setInterval(callable $cb, float $timeout): array
     {
@@ -88,7 +88,7 @@ class Loop
     /**
      * Stops a running interval.
      *
-     * @param array{0:string, 1:boolean} $intervalId
+     * @param array{0:string, 1:bool} $intervalId
      */
     public function clearInterval(array $intervalId): void
     {

--- a/lib/Loop/functions.php
+++ b/lib/Loop/functions.php
@@ -18,7 +18,7 @@ function setTimeout(callable $cb, float $timeout): void
  * The value this function returns can be used to stop the interval with
  * clearInterval.
  *
- * @return array{0:string, 1:boolean}
+ * @return array{0:string, 1:bool}
  */
 function setInterval(callable $cb, float $timeout): array
 {
@@ -28,7 +28,7 @@ function setInterval(callable $cb, float $timeout): array
 /**
  * Stops a running interval.
  *
- * @param array{0:string, 1:boolean} $intervalId
+ * @param array{0:string, 1:bool} $intervalId
  */
 function clearInterval(array $intervalId): void
 {
@@ -134,7 +134,7 @@ function stop(): void
 /**
  * Retrieves or sets the global Loop object.
  */
-function instance(Loop $newLoop = null): Loop
+function instance(?Loop $newLoop = null): Loop
 {
     static $loop;
     if ($newLoop instanceof Loop) {

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -53,7 +53,7 @@ class Promise
      * Each are callbacks that map to $this->fulfill and $this->reject.
      * Using the executor is optional.
      */
-    public function __construct(callable $executor = null)
+    public function __construct(?callable $executor = null)
     {
         if (is_callable($executor)) {
             $executor(
@@ -84,7 +84,7 @@ class Promise
      *
      * @return Promise<TReturn>
      */
-    public function then(callable $onFulfilled = null, callable $onRejected = null): Promise
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null): Promise
     {
         // This new subPromise will be returned from this function, and will
         // be fulfilled with the result of the onFulfilled or onRejected event
@@ -225,7 +225,7 @@ class Promise
      *
      * @param Promise<TReturn> $subPromise
      */
-    private function invokeCallback(Promise $subPromise, callable $callBack = null): void
+    private function invokeCallback(Promise $subPromise, ?callable $callBack = null): void
     {
         // We use 'nextTick' to ensure that the event handlers are always
         // triggered outside of the calling stack in which they were originally

--- a/lib/WildcardEmitterTrait.php
+++ b/lib/WildcardEmitterTrait.php
@@ -82,7 +82,7 @@ trait WildcardEmitterTrait
      * Lastly, if there are 5 event handlers for an event. The continueCallback
      * will be called at most 4 times.
      */
-    public function emit(string $eventName, array $arguments = [], callable $continueCallBack = null): bool
+    public function emit(string $eventName, array $arguments = [], ?callable $continueCallBack = null): bool
     {
         if (\is_null($continueCallBack)) {
             foreach ($this->listeners($eventName) as $listener) {
@@ -195,7 +195,7 @@ trait WildcardEmitterTrait
      * removed. If it is not specified, every listener for every event is
      * removed.
      */
-    public function removeAllListeners(string $eventName = null): void
+    public function removeAllListeners(?string $eventName = null): void
     {
         if (\is_null($eventName)) {
             $this->listeners = [];


### PR DESCRIPTION
php-cs-fixer 3.49 (or some recent minor release) wants to use the `?` (nullable) syntax on optional parameters.
That syntax has been supported for quite a while since PHP https://www.php.net/manual/en/migration71.new-features.php

In the cases here, as well as the default value of the parameter being `null`, the `?` explicitly allows the caller to pass the value `null` if they want.

And some mentions of type `boolean` change to just `bool` - that seems "a good thing" because of
https://www.php.net/manual/en/language.types.declarations.php
"Warning
Name aliases for scalar types (bool, int, float, string) are not supported. Instead, they are treated as class or interface names. For example, using boolean as a type declaration will require the value to be an [instanceof](https://www.php.net/manual/en/language.operators.type.php) the class or interface boolean, rather than of type bool"

php-cs-fixer has only found things to fix in the PHP doc for this `bool` thing, so no actual code effect to think about.

These seem reasonable, I don't see how it can break any existing usage.