### PR TITLE
chore: bump dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,9 +47,9 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.56",
-        "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-phpunit": "^1.3",
-        "phpstan/phpstan-strict-rules": "^1.5",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-phpunit": "^1.4",
+        "phpstan/phpstan-strict-rules": "^1.6",
         "phpstan/extension-installer": "^1.3",
         "phpunit/phpunit" : "^9.6"
     },


### PR DESCRIPTION
`phpstan` `1.11` was released yesterday and has quite a lot of code changes. So I wanted to make sure that the code is passing with the new `phpstan`