### PR TITLE
Changes for 5.1 series

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,9 @@
-/examples          export-ignore
-/tests             export-ignore
+/.github/          export-ignore
+/examples/         export-ignore
+/tests/            export-ignore
 /.gitattributes    export-ignore
 /.gitignore        export-ignore
+/.php_cs.dist      export-ignore
 /.travis.yml       export-ignore
 /CHANGELOG.md      export-ignore
 /README.md         export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,7 @@
 /.gitattributes    export-ignore
 /.gitignore        export-ignore
 /.php_cs.dist      export-ignore
-/.travis.yml       export-ignore
 /CHANGELOG.md      export-ignore
 /README.md         export-ignore
 /_config.yml       export-ignore
-/phpunit.xml.dist  export-ignore
+/phpstan.neon      export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             code-analysis: 'yes'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             code-analysis: 'yes'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
@@ -33,10 +33,10 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
@@ -59,5 +59,5 @@ jobs:
         run: vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover clover.xml
 
       - name: Code Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         if: matrix.coverage != 'none'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         coverage: ['pcov']
         code-analysis: ['no']
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
         code-analysis: ['no']
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,5 @@ jobs:
         run: vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover clover.xml
 
       - name: Code Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: matrix.coverage != 'none'

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.17.1",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0"
+        "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.6"
     },
     "scripts": {
         "phpstan": [

--- a/examples/curl.php
+++ b/examples/curl.php
@@ -102,7 +102,7 @@ function curl_multi_loop_scheduler($mh, callable $done)
             break;
 
         default:
-            throw Exception('Curl error: '.curl_multi_strerror($mrc));
+            throw new Exception('Curl error: '.curl_multi_strerror($mrc));
     }
 }
 

--- a/lib/Loop/Loop.php
+++ b/lib/Loop/Loop.php
@@ -265,7 +265,7 @@ class Loop
      * If $timeout is 0, it will return immediately. If $timeout is null, it
      * will wait indefinitely.
      *
-     * @param float|null timeout
+     * @param float|null $timeout
      */
     protected function runStreams($timeout)
     {

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -219,8 +219,6 @@ class Promise
      * This method makes sure that the result of these callbacks are handled
      * correctly, and any chained promises are also correctly fulfilled or
      * rejected.
-     *
-     * @param callable $callBack
      */
     private function invokeCallback(Promise $subPromise, callable $callBack = null)
     {

--- a/lib/coroutine.php
+++ b/lib/coroutine.php
@@ -42,8 +42,6 @@ use Throwable;
  *
  * });
  *
- * @return \Sabre\Event\Promise
- *
  * @psalm-template TReturn
  * @psalm-param callable():\Generator<mixed, mixed, mixed, TReturn> $gen
  * @psalm-return Promise<TReturn>

--- a/tests/Event/CoroutineTest.php
+++ b/tests/Event/CoroutineTest.php
@@ -56,7 +56,7 @@ class CoroutineTest extends \PHPUnit\Framework\TestCase
                 // This line is unreachable, but it's our control
                 $start += 4;
             } catch (\Exception $e) {
-                $start += $e->getMessage();
+                $start += (int) $e->getMessage();
             }
         });
 
@@ -78,7 +78,7 @@ class CoroutineTest extends \PHPUnit\Framework\TestCase
                 // This line is unreachable, but it's our control
                 $start += 4;
             } catch (\LogicException $e) {
-                $start += $e->getMessage();
+                $start += (int) $e->getMessage();
             }
         });
 
@@ -115,13 +115,13 @@ class CoroutineTest extends \PHPUnit\Framework\TestCase
                 // This line is unreachable, but it's our control
                 $start += 4;
             } catch (\Exception $e) {
-                $start += $e->getMessage();
+                $start += (int) $e->getMessage();
             }
         });
 
         $this->assertEquals(1, $start);
 
-        $promise->reject(new \Exception((string) 2));
+        $promise->reject(new \Exception('2'));
         Loop\run();
 
         $this->assertEquals(3, $start);
@@ -156,7 +156,7 @@ class CoroutineTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(1, $start);
 
-        $promise->reject(new \Exception((string) 2));
+        $promise->reject(new \Exception('2'));
         Loop\run();
 
         $this->assertEquals(3, $start);


### PR DESCRIPTION
Things from:

#94 Update .gitattributes
#96 Minor fixups
#108 Update deprecated GitHub workflow items
Add PHP 8.2 and 8.3 to CI
and other things from master of the last 2 years that I don't think will cause any problem all the way back to PHP 7.1

This gets a 5.1 branch that has up-to-date CI that passes for PHP 7.1 through 8.3.