### PR TITLE
[5.1] Add PHP 8.4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Code Analysis (PHP CS-Fixer)
         if: matrix.code-analysis == 'yes'
-        run: php vendor/bin/php-cs-fixer fix --dry-run --diff
+        run: PHP_CS_FIXER_IGNORE_ENV=true php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)
         if: matrix.code-analysis == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
           - php-versions: '7.1'
             coverage: 'none'
             code-analysis: 'yes'
+          - php-versions: '8.4'
+            coverage: 'pcov'
+            code-analysis: 'yes'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/lib/EmitterInterface.php
+++ b/lib/EmitterInterface.php
@@ -47,7 +47,7 @@ interface EmitterInterface
      * Lastly, if there are 5 event handlers for an event. The continueCallback
      * will be called at most 4 times.
      */
-    public function emit(string $eventName, array $arguments = [], callable $continueCallBack = null): bool;
+    public function emit(string $eventName, array $arguments = [], ?callable $continueCallBack = null): bool;
 
     /**
      * Returns the list of listeners for an event.
@@ -74,5 +74,5 @@ interface EmitterInterface
      * removed. If it is not specified, every listener for every event is
      * removed.
      */
-    public function removeAllListeners(string $eventName = null);
+    public function removeAllListeners(?string $eventName = null);
 }

--- a/lib/EmitterTrait.php
+++ b/lib/EmitterTrait.php
@@ -73,7 +73,7 @@ trait EmitterTrait
      * Lastly, if there are 5 event handlers for an event. The continueCallback
      * will be called at most 4 times.
      */
-    public function emit(string $eventName, array $arguments = [], callable $continueCallBack = null): bool
+    public function emit(string $eventName, array $arguments = [], ?callable $continueCallBack = null): bool
     {
         if (\is_null($continueCallBack)) {
             foreach ($this->listeners($eventName) as $listener) {
@@ -160,7 +160,7 @@ trait EmitterTrait
      * removed. If it is not specified, every listener for every event is
      * removed.
      */
-    public function removeAllListeners(string $eventName = null)
+    public function removeAllListeners(?string $eventName = null)
     {
         if (!\is_null($eventName)) {
             unset($this->listeners[$eventName]);

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -58,7 +58,7 @@ class Promise
      * Each are callbacks that map to $this->fulfill and $this->reject.
      * Using the executor is optional.
      */
-    public function __construct(callable $executor = null)
+    public function __construct(?callable $executor = null)
     {
         if ($executor) {
             $executor(
@@ -87,7 +87,7 @@ class Promise
      * If either of the callbacks throw an exception, the returned promise will
      * be rejected and the exception will be passed back.
      */
-    public function then(callable $onFulfilled = null, callable $onRejected = null): Promise
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null): Promise
     {
         // This new subPromise will be returned from this function, and will
         // be fulfilled with the result of the onFulfilled or onRejected event
@@ -220,7 +220,7 @@ class Promise
      * correctly, and any chained promises are also correctly fulfilled or
      * rejected.
      */
-    private function invokeCallback(Promise $subPromise, callable $callBack = null)
+    private function invokeCallback(Promise $subPromise, ?callable $callBack = null)
     {
         // We use 'nextTick' to ensure that the event handlers are always
         // triggered outside of the calling stack in which they were originally

--- a/lib/WildcardEmitterTrait.php
+++ b/lib/WildcardEmitterTrait.php
@@ -82,7 +82,7 @@ trait WildcardEmitterTrait
      * Lastly, if there are 5 event handlers for an event. The continueCallback
      * will be called at most 4 times.
      */
-    public function emit(string $eventName, array $arguments = [], callable $continueCallBack = null): bool
+    public function emit(string $eventName, array $arguments = [], ?callable $continueCallBack = null): bool
     {
         if (\is_null($continueCallBack)) {
             foreach ($this->listeners($eventName) as $listener) {
@@ -195,7 +195,7 @@ trait WildcardEmitterTrait
      * removed. If it is not specified, every listener for every event is
      * removed.
      */
-    public function removeAllListeners(string $eventName = null)
+    public function removeAllListeners(?string $eventName = null)
     {
         if (\is_null($eventName)) {
             $this->listeners = [];


### PR DESCRIPTION
Part of issue #123 
- add PHP 8.4 to CI
- chore: run cs-fixer regardless of PHP version (forcing it to run on PHP 8.4 in CI - it passes)
- explicitly mark nullable parameters like `?callback` `?string`. This was supported since PHP 7.1, so that is very convenient because the 5.1.x release series still supports all the way back to PHP 7.1
