### PR TITLE
chore: allow phpstan v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,18 @@ jobs:
         coverage: ['pcov']
         code-style: ['no']
         code-analysis: ['no']
+        code-analysis-extensions: ['no']
         include:
           - php-versions: '7.1'
             coverage: 'none'
             code-style: 'yes'
             code-analysis: 'yes'
+            code-analysis-extensions: 'no'
           - php-versions: '8.4'
             coverage: 'pcov'
             code-style: 'no'
             code-analysis: 'yes'
+            code-analysis-extensions: 'yes'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,6 +55,12 @@ jobs:
 
       - name: Install composer dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Extra components for phpstan v1
+        if: matrix.code-analysis-extensions == 'yes'
+        run: |
+          composer config --no-plugins allow-plugins.phpstan/extension-installer true
+          composer require --dev phpstan/phpstan-phpunit phpstan/phpstan-strict-rules phpstan/extension-installer
 
       - name: Code Analysis (PHP CS-Fixer)
         if: matrix.code-style == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,16 @@ jobs:
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
+        code-style: ['no']
         code-analysis: ['no']
         include:
           - php-versions: '7.1'
             coverage: 'none'
+            code-style: 'yes'
             code-analysis: 'yes'
           - php-versions: '8.4'
             coverage: 'pcov'
+            code-style: 'no'
             code-analysis: 'yes'
     steps:
       - name: Checkout
@@ -51,7 +54,7 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Analysis (PHP CS-Fixer)
-        if: matrix.code-analysis == 'yes'
+        if: matrix.code-style == 'yes'
         run: PHP_CS_FIXER_IGNORE_ENV=true php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)

--- a/composer.json
+++ b/composer.json
@@ -46,13 +46,14 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.17.1",
-        "phpstan/phpstan": "^0.12",
+        "friendsofphp/php-cs-fixer": "~2.17.1 || ^3.60",
+        "phpstan/phpstan": "^0.12 || ^1.1",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.6"
     },
     "scripts": {
         "phpstan": [
-            "phpstan analyse lib tests"
+            "phpstan analyse lib",
+            "phpstan analyse tests"
         ],
         "cs-fixer": [
             "php-cs-fixer fix"

--- a/lib/EmitterInterface.php
+++ b/lib/EmitterInterface.php
@@ -74,5 +74,5 @@ interface EmitterInterface
      * removed. If it is not specified, every listener for every event is
      * removed.
      */
-    public function removeAllListeners(?string $eventName = null);
+    public function removeAllListeners(string $eventName = null);
 }

--- a/lib/EmitterInterface.php
+++ b/lib/EmitterInterface.php
@@ -47,7 +47,7 @@ interface EmitterInterface
      * Lastly, if there are 5 event handlers for an event. The continueCallback
      * will be called at most 4 times.
      */
-    public function emit(string $eventName, array $arguments = [], ?callable $continueCallBack = null): bool;
+    public function emit(string $eventName, array $arguments = [], callable $continueCallBack = null): bool;
 
     /**
      * Returns the list of listeners for an event.

--- a/lib/EmitterTrait.php
+++ b/lib/EmitterTrait.php
@@ -160,7 +160,7 @@ trait EmitterTrait
      * removed. If it is not specified, every listener for every event is
      * removed.
      */
-    public function removeAllListeners(?string $eventName = null)
+    public function removeAllListeners(string $eventName = null)
     {
         if (!\is_null($eventName)) {
             unset($this->listeners[$eventName]);

--- a/lib/EmitterTrait.php
+++ b/lib/EmitterTrait.php
@@ -73,7 +73,7 @@ trait EmitterTrait
      * Lastly, if there are 5 event handlers for an event. The continueCallback
      * will be called at most 4 times.
      */
-    public function emit(string $eventName, array $arguments = [], ?callable $continueCallBack = null): bool
+    public function emit(string $eventName, array $arguments = [], callable $continueCallBack = null): bool
     {
         if (\is_null($continueCallBack)) {
             foreach ($this->listeners($eventName) as $listener) {

--- a/lib/Loop/functions.php
+++ b/lib/Loop/functions.php
@@ -130,7 +130,7 @@ function stop()
 /**
  * Retrieves or sets the global Loop object.
  */
-function instance(?Loop $newLoop = null): Loop
+function instance(Loop $newLoop = null): Loop
 {
     static $loop;
     if ($newLoop) {

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -58,7 +58,7 @@ class Promise
      * Each are callbacks that map to $this->fulfill and $this->reject.
      * Using the executor is optional.
      */
-    public function __construct(?callable $executor = null)
+    public function __construct(callable $executor = null)
     {
         if ($executor) {
             $executor(
@@ -87,7 +87,7 @@ class Promise
      * If either of the callbacks throw an exception, the returned promise will
      * be rejected and the exception will be passed back.
      */
-    public function then(?callable $onFulfilled = null, ?callable $onRejected = null): Promise
+    public function then(callable $onFulfilled = null, callable $onRejected = null): Promise
     {
         // This new subPromise will be returned from this function, and will
         // be fulfilled with the result of the onFulfilled or onRejected event
@@ -220,7 +220,7 @@ class Promise
      * correctly, and any chained promises are also correctly fulfilled or
      * rejected.
      */
-    private function invokeCallback(Promise $subPromise, ?callable $callBack = null)
+    private function invokeCallback(Promise $subPromise, callable $callBack = null)
     {
         // We use 'nextTick' to ensure that the event handlers are always
         // triggered outside of the calling stack in which they were originally

--- a/lib/WildcardEmitterTrait.php
+++ b/lib/WildcardEmitterTrait.php
@@ -82,7 +82,7 @@ trait WildcardEmitterTrait
      * Lastly, if there are 5 event handlers for an event. The continueCallback
      * will be called at most 4 times.
      */
-    public function emit(string $eventName, array $arguments = [], ?callable $continueCallBack = null): bool
+    public function emit(string $eventName, array $arguments = [], callable $continueCallBack = null): bool
     {
         if (\is_null($continueCallBack)) {
             foreach ($this->listeners($eventName) as $listener) {
@@ -195,7 +195,7 @@ trait WildcardEmitterTrait
      * removed. If it is not specified, every listener for every event is
      * removed.
      */
-    public function removeAllListeners(?string $eventName = null)
+    public function removeAllListeners(string $eventName = null)
     {
         if (\is_null($eventName)) {
             $this->listeners = [];


### PR DESCRIPTION
"uri" repo is working running phpstan 1.11 on PHP 8.4
So I am hoping that I could find some config that will allow old phpstan 0.12 to keep running with PHP 7.1, and phpstan 1.11 to run with PHP 8.4
But phpstan 1.11 with PHP 8.4 is giving:
"Result is incomplete because of severe errors"
"Some parallel worker jobs have not finished. while running parallel worker"
But the deprecated messages that are logged are similar to what "uri" logs.
There must be difference in something!