### PR TITLE
chore: allow php-cs-fixer major version 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,16 @@ jobs:
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
+        code-style: ['yes']
         code-analysis: ['no']
         include:
           - php-versions: '7.1'
             coverage: 'none'
+            code-style: 'yes'
             code-analysis: 'yes'
           - php-versions: '8.4'
             coverage: 'pcov'
+            code-style: 'yes'
             code-analysis: 'yes'
     steps:
       - name: Checkout
@@ -51,7 +54,7 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Analysis (PHP CS-Fixer)
-        if: matrix.code-analysis == 'yes'
+        if: matrix.code-style == 'yes'
         run: PHP_CS_FIXER_IGNORE_ENV=true php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 tests/cov
 tests/.phpunit.result.cache
 .php_cs.cache
+.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,17 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor')
+    ->in(__DIR__);
+
+$config = new PhpCsFixer\Config();
+$config->setRules([
+    '@PSR1' => true,
+    '@Symfony' => true,
+    'nullable_type_declaration' => [
+        'syntax' => 'question_mark',
+    ],
+    'nullable_type_declaration_for_default_null_value' => true,
+]);
+$config->setFinder($finder);
+return $config;

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,6 +8,7 @@ $config = new PhpCsFixer\Config();
 $config->setRules([
     '@PSR1' => true,
     '@Symfony' => true,
+    'blank_line_between_import_groups' => false,
     'nullable_type_declaration' => [
         'syntax' => 'question_mark',
     ],

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,7 +6,12 @@ $config->getFinder()
     ->in(__DIR__);
 $config->setRules([
     '@PSR1' => true,
-    '@Symfony' => true
+    '@Symfony' => true,
+    'ordered_imports' => [
+        'imports_order' => [
+            'class', 'function', 'const',
+        ],
+    ],
 ]);
 
 return $config;

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.17.1",
+        "friendsofphp/php-cs-fixer": "~2.17.1||^3.63",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.6"
     },
@@ -55,7 +55,7 @@
             "phpstan analyse lib tests"
         ],
         "cs-fixer": [
-            "php-cs-fixer fix"
+            "PHP_CS_FIXER_IGNORE_ENV=true php-cs-fixer fix"
         ],
         "phpunit": [
             "phpunit --configuration tests/phpunit.xml"

--- a/examples/curl.php
+++ b/examples/curl.php
@@ -1,5 +1,7 @@
 #!/usr/bin/env php
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 /*
  * The following example demonstrates doing asynchronous HTTP requests with
@@ -26,10 +28,10 @@ $ch2 = curl_init();
 curl_setopt_array($ch1, CURLOPT_URL, 'http://httpbin.org/delay/5');
 curl_setopt_array($ch2, CURLOPT_URL, 'http://httpbin.org/delay/5');
 
-//create the multiple cURL handle
+// create the multiple cURL handle
 $mh = curl_multi_init();
 
-//add the two handles
+// add the two handles
 curl_multi_add_handle($mh, $ch1);
 curl_multi_add_handle($mh, $ch2);
 
@@ -112,7 +114,7 @@ curl_multi_loop_scheduler($mh, function () {
 
 Loop\run();
 
-//close the handles
+// close the handles
 curl_multi_remove_handle($mh, $ch1);
 curl_multi_remove_handle($mh, $ch2);
 curl_multi_close($mh);

--- a/examples/promise.php
+++ b/examples/promise.php
@@ -1,9 +1,12 @@
 #!/usr/bin/env php
-<?php declare(strict_types=1);
+<?php
 
-use function Sabre\Event\coroutine;
+declare(strict_types=1);
+
 use Sabre\Event\Loop;
 use Sabre\Event\Promise;
+
+use function Sabre\Event\coroutine;
 
 require __DIR__.'/../vendor/autoload.php';
 
@@ -25,6 +28,7 @@ Loop\setTimeout(function () use ($promise) {
 $result = $promise
     ->then(function ($value) {
         echo "Step 2\n";
+
         // Immediately returning a new value.
         return $value.' world';
     })
@@ -42,6 +46,7 @@ $result = $promise
     })
     ->then(function ($value) {
         echo "Step 4\n";
+
         // This is the final event handler.
         return $value.' you rock!';
     })

--- a/examples/promise.php
+++ b/examples/promise.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 
 use Sabre\Event\Loop;
 use Sabre\Event\Promise;
-
 use function Sabre\Event\coroutine;
 
 require __DIR__.'/../vendor/autoload.php';

--- a/examples/tail.php
+++ b/examples/tail.php
@@ -1,5 +1,7 @@
 #!/usr/bin/env php
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 /*
  * This example can be used to logfile processing and basically wraps the tail

--- a/lib/Loop/Loop.php
+++ b/lib/Loop/Loop.php
@@ -24,7 +24,7 @@ class Loop
      */
     public function setTimeout(callable $cb, float $timeout)
     {
-        $triggerTime = microtime(true) + ($timeout);
+        $triggerTime = microtime(true) + $timeout;
 
         if (!$this->timers) {
             // Special case when the timers array was empty.

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sabre\Event;
 
 use Exception;
-use Throwable;
 
 /**
  * An implementation of the Promise pattern.
@@ -30,17 +29,17 @@ class Promise
     /**
      * The asynchronous operation is pending.
      */
-    const PENDING = 0;
+    public const PENDING = 0;
 
     /**
      * The asynchronous operation has completed, and has a result.
      */
-    const FULFILLED = 1;
+    public const FULFILLED = 1;
 
     /**
      * The asynchronous operation has completed with an error.
      */
-    const REJECTED = 2;
+    public const REJECTED = 2;
 
     /**
      * The current state of this promise.
@@ -128,8 +127,6 @@ class Promise
 
     /**
      * Marks this promise as fulfilled and sets its return value.
-     *
-     * @param mixed $value
      */
     public function fulfill($value = null)
     {
@@ -146,7 +143,7 @@ class Promise
     /**
      * Marks this promise as rejected, and set its rejection reason.
      */
-    public function reject(Throwable $reason)
+    public function reject(\Throwable $reason)
     {
         if (self::PENDING !== $this->state) {
             throw new PromiseAlreadyResolvedException('This promise is already resolved, and you\'re not allowed to resolve a promise more than once');
@@ -169,7 +166,6 @@ class Promise
      * one. In PHP it might be useful to call this on the last promise in a
      * chain.
      *
-     * @return mixed
      * @psalm-return TReturn
      */
     public function wait()
@@ -208,10 +204,8 @@ class Promise
      *
      * If the promise was fulfilled, this will be the result value. If the
      * promise was rejected, this property hold the rejection reason.
-     *
-     * @var mixed
      */
-    protected $value = null;
+    protected $value;
 
     /**
      * This method is used to call either an onFulfilled or onRejected callback.
@@ -242,7 +236,7 @@ class Promise
                         // immediately fulfill the chained promise.
                         $subPromise->fulfill($result);
                     }
-                } catch (Throwable $e) {
+                } catch (\Throwable $e) {
                     // If the event handler threw an exception, we need to make sure that
                     // the chained promise is rejected as well.
                     $subPromise->reject($e);

--- a/lib/Promise/functions.php
+++ b/lib/Promise/functions.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sabre\Event\Promise;
 
 use Sabre\Event\Promise;
-use Throwable;
 
 /**
  * This file contains a set of functions that are useful for dealing with the
@@ -101,8 +100,6 @@ function race(array $promises): Promise
  *
  * If the value is a promise, the returned promise will attach itself to that
  * promise and eventually get the same state as the followed promise.
- *
- * @param mixed $value
  */
 function resolve($value): Promise
 {
@@ -119,7 +116,7 @@ function resolve($value): Promise
 /**
  * Returns a Promise that will reject with the given reason.
  */
-function reject(Throwable $reason): Promise
+function reject(\Throwable $reason): Promise
 {
     $promise = new Promise();
     $promise->reject($reason);

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    const VERSION = '5.1.6';
+    public const VERSION = '5.1.6';
 }

--- a/lib/coroutine.php
+++ b/lib/coroutine.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sabre\Event;
 
 use Generator;
-use Throwable;
 
 /**
  * Turn asynchronous promise-based code into something that looks synchronous
@@ -43,7 +42,9 @@ use Throwable;
  * });
  *
  * @psalm-template TReturn
+ *
  * @psalm-param callable():\Generator<mixed, mixed, mixed, TReturn> $gen
+ *
  * @psalm-return Promise<TReturn>
  *
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
@@ -53,7 +54,7 @@ use Throwable;
 function coroutine(callable $gen): Promise
 {
     $generator = $gen();
-    if (!$generator instanceof Generator) {
+    if (!$generator instanceof \Generator) {
         throw new \InvalidArgumentException('You must pass a generator function');
     }
 
@@ -73,11 +74,11 @@ function coroutine(callable $gen): Promise
                         $generator->send($value);
                         $advanceGenerator();
                     },
-                    function (Throwable $reason) use ($generator, $advanceGenerator) {
+                    function (\Throwable $reason) use ($generator, $advanceGenerator) {
                         $generator->throw($reason);
                         $advanceGenerator();
                     }
-                )->otherwise(function (Throwable $reason) use ($promise) {
+                )->otherwise(function (\Throwable $reason) use ($promise) {
                     // This error handler would be called, if something in the
                     // generator throws an exception, and it's not caught
                     // locally.
@@ -102,7 +103,7 @@ function coroutine(callable $gen): Promise
             if ($returnValue instanceof Promise) {
                 $returnValue->then(function ($value) use ($promise) {
                     $promise->fulfill($value);
-                }, function (Throwable $reason) use ($promise) {
+                }, function (\Throwable $reason) use ($promise) {
                     $promise->reject($reason);
                 });
             } else {
@@ -113,7 +114,7 @@ function coroutine(callable $gen): Promise
 
     try {
         $advanceGenerator();
-    } catch (Throwable $e) {
+    } catch (\Throwable $e) {
         $promise->reject($e);
     }
 

--- a/tests/Event/CoroutineTest.php
+++ b/tests/Event/CoroutineTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Event;
 
-use Exception;
-
 class CoroutineTest extends \PHPUnit\Framework\TestCase
 {
     public function testNonGenerator()
@@ -46,7 +44,7 @@ class CoroutineTest extends \PHPUnit\Framework\TestCase
     {
         $start = 0;
         $promise = new Promise(function ($fulfill, $reject) {
-            $reject(new Exception('2'));
+            $reject(new \Exception('2'));
         });
 
         coroutine(function () use (&$start, $promise) {

--- a/tests/Event/Promise/FunctionsTest.php
+++ b/tests/Event/Promise/FunctionsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Event\Promise;
 
-use Exception;
 use Sabre\Event\Loop;
 use Sabre\Event\Promise;
 
@@ -53,10 +52,10 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
             }
         );
 
-        $promise1->reject(new Exception('1'));
+        $promise1->reject(new \Exception('1'));
         Loop\run();
         $this->assertEquals('1', $finalValue->getMessage());
-        $promise2->reject(new Exception('2'));
+        $promise2->reject(new \Exception('2'));
         Loop\run();
         $this->assertEquals(1, $finalValue->getMessage());
     }
@@ -78,10 +77,10 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
             }
         );
 
-        $promise1->reject(new Exception('1'));
+        $promise1->reject(new \Exception('1'));
         Loop\run();
         $this->assertEquals(1, $finalValue->getMessage());
-        $promise2->fulfill(new Exception('2'));
+        $promise2->fulfill(new \Exception('2'));
         Loop\run();
         $this->assertEquals(1, $finalValue->getMessage());
     }
@@ -124,10 +123,10 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
             }
         );
 
-        $promise1->reject(new Exception('1'));
+        $promise1->reject(new \Exception('1'));
         Loop\run();
         $this->assertEquals(1, $finalValue->getMessage());
-        $promise2->reject(new Exception('2'));
+        $promise2->reject(new \Exception('2'));
         Loop\run();
         $this->assertEquals(1, $finalValue->getMessage());
     }
@@ -162,7 +161,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     {
         $finalValue = 0;
 
-        $promise = reject(new Exception('1'));
+        $promise = reject(new \Exception('1'));
         $promise->then(function ($value) use (&$finalValue) {
             $finalValue = 'im broken';
         }, function ($reason) use (&$finalValue) {

--- a/tests/Event/Promise/PromiseTest.php
+++ b/tests/Event/Promise/PromiseTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Event\Promise;
 
-use Exception;
 use Sabre\Event\Loop;
 use Sabre\Event\Promise;
 use Sabre\Event\PromiseAlreadyResolvedException;
@@ -29,7 +28,7 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
     {
         $finalValue = 0;
         $promise = new Promise();
-        $promise->reject(new Exception('1'));
+        $promise->reject(new \Exception('1'));
 
         $promise->then(null, function ($value) use (&$finalValue) {
             $finalValue = $value->getMessage() + 2;
@@ -105,7 +104,7 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
             $finalValue = $value->getMessage() + 2;
         });
 
-        $promise->reject(new Exception('4'));
+        $promise->reject(new \Exception('4'));
         Loop\run();
 
         $this->assertEquals(6, $finalValue);
@@ -126,7 +125,7 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
     public function testExecutorFail()
     {
         $promise = (new Promise(function ($success, $fail) {
-            $fail(new Exception('hi'));
+            $fail(new \Exception('hi'));
         }))->then(function ($result) use (&$realResult) {
             $realResult = 'incorrect';
         })->otherwise(function ($reason) use (&$realResult) {
@@ -149,8 +148,8 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(PromiseAlreadyResolvedException::class);
         $promise = new Promise();
-        $promise->reject(new Exception('1'));
-        $promise->reject(new Exception('1'));
+        $promise->reject(new \Exception('1'));
+        $promise->reject(new \Exception('1'));
     }
 
     public function testFromFailureHandler()
@@ -167,7 +166,7 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
         });
 
         $this->assertEquals(0, $ok);
-        $promise->reject(new Exception('foo'));
+        $promise->reject(new \Exception('foo'));
         Loop\run();
 
         $this->assertEquals(1, $ok);
@@ -211,7 +210,7 @@ class PromiseTest extends \PHPUnit\Framework\TestCase
     {
         $promise = new Promise();
         Loop\nextTick(function () use ($promise) {
-            $promise->reject(new Exception('foo'));
+            $promise->reject(new \Exception('foo'));
         });
         try {
             $promise->wait();


### PR DESCRIPTION
Add the ability to use php-cs-fixer major version 3.

Add `.php-cs-fixer.dist.php` (the settings of php-cs-fixer for major version 3) and put the `nullable_type_declaration` check into it. This is the main reason for the PR - it makes sure that any of these that will emit deprecation messages in PHP 8.4, are found in CI.

Run cs-fixer on PHP 8.4.
Leave the old cs-fixer still running on PHP 7.1.
And run cs-fixer on every PHP version, to be sure. In CI, `composer` will choose whether to use major version 2 or 3 of php-cs-fixer.

The newer cs-fixer v3 makes various nice fixes that do not break on PHP 7.1.
The old cs-fixer v2 is happy with the changes, it does not try to change them back - that is nice.

This is only needed for this old release series that still has PHP 7.1 support. We can run both cs-fixer and phpstan (and phpunit) on PHP 7.1 through 8.4. I think that helps give confidence that the code works across that range of PHP versions.

Note: when I forward-port all this stuff to later major releases, I won't need to do all this tweaking because we move to supporting only PHP 7.4 and up.

Similar to:
  https://github.com/sabre-io/xml/pull/290
  https://github.com/sabre-io/http/pull/243
  https://github.com/sabre-io/uri/pull/117

Note: for php-cs-fixer v3 I also had to set:
```
'blank_line_between_import_groups' => false
```

Because v2 does it like that, and I couldn't find a way to force v2 to put a blank line between each group of "use" statements.

And define `ordered_imports` for php-cs-fixer v2, so that it works the way that v3 works.

That is fine for this 5.1 branch - in the later major release branches I won't need to fine-tune "odd" php-cs-fixer rules.
The "odd" rules were only relevant to `examples/promise.php` - that has ordinary `use` statements and a `use function` statement. So there was no "real" run-time code that was impacted.
