### PR TITLE
[5.1] bump php-cs-fixer to minimum 3.64

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.17.1||^3.63",
+        "friendsofphp/php-cs-fixer": "~2.17.1||^3.64",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.6"
     },


### PR DESCRIPTION
Just confirming that php-cs-fixer 3.64 is not wanting to make any changes here.
CI is green, so I will merge this. No need for any release, there is no code changed.