### PR TITLE
Add PHP 8.4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
+        code-style: ['no']
         code-analysis: ['no']
         include:
           - php-versions: '7.4'
             coverage: 'none'
+            code-style: 'yes'
+            code-analysis: 'yes'
+          - php-versions: '8.4'
+            coverage: 'pcov'
+            code-style: 'yes'
             code-analysis: 'yes'
     steps:
       - name: Checkout
@@ -48,8 +54,8 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Analysis (PHP CS-Fixer)
-        if: matrix.code-analysis == 'yes'
-        run: php vendor/bin/php-cs-fixer fix --dry-run --diff
+        if: matrix.code-style == 'yes'
+        run: PHP_CS_FIXER_IGNORE_ENV=true php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)
         if: matrix.code-analysis == 'yes'

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -10,6 +10,10 @@ $config->getFinder()
 $config->setRules([
     '@PSR1' => true,
     '@Symfony' => true,
+    'nullable_type_declaration' => [
+        'syntax' => 'question_mark',
+    ],
+    'nullable_type_declaration_for_default_null_value' => true,
 ]);
 
 return $config;

--- a/composer.json
+++ b/composer.json
@@ -46,11 +46,11 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.56",
-        "phpstan/phpstan": "^1.11",
+        "friendsofphp/php-cs-fixer": "^3.64",
+        "phpstan/phpstan": "^1.12",
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-strict-rules": "^1.6",
-        "phpstan/extension-installer": "^1.3",
+        "phpstan/extension-installer": "^1.4",
         "phpunit/phpunit" : "^9.6"
     },
     "scripts": {
@@ -58,7 +58,7 @@
             "phpstan analyse lib tests"
         ],
         "cs-fixer": [
-            "php-cs-fixer fix"
+            "PHP_CS_FIXER_IGNORE_ENV=true php-cs-fixer fix"
         ],
         "phpunit": [
             "phpunit --configuration tests/phpunit.xml"


### PR DESCRIPTION
https://github.com/sabre-io/event/actions/runs/10736299709/job/29775402117?pr=136
php-cs-fixer phpstan phpunit all pass on PHP 8.4

This is a tooling/CI change only. No more code changes are required.
