### PR TITLE
chore: adjust code for cs-fixer no-useless-else

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.91",
+        "friendsofphp/php-cs-fixer": "^3.94",
         "phpstan/phpstan": "^1.12",
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-strict-rules": "^1.6",

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -186,16 +186,15 @@ class Promise
         if (self::FULFILLED === $this->state) {
             // If the state of this promise is fulfilled, we can return the value.
             return $this->value;
-        } else {
-            // If we got here, it means that the asynchronous operation
-            // errored. Therefore, we need to throw an exception.
-            if ($this->value instanceof \Throwable) {
-                throw $this->value;
-            }
-            // The state should have been REJECTED, with "value" a Throwable
-            // But "value" was not a Throwable. So throw a more general exception.
-            throw new \LogicException('The Promise was not fulfilled but no exception was specified');
         }
+        // If we got here, it means that the asynchronous operation
+        // errored. Therefore, we need to throw an exception.
+        if ($this->value instanceof \Throwable) {
+            throw $this->value;
+        }
+        // The state should have been REJECTED, with "value" a Throwable
+        // But "value" was not a Throwable. So throw a more general exception.
+        throw new \LogicException('The Promise was not fulfilled but no exception was specified');
     }
 
     /**

--- a/lib/Promise/functions.php
+++ b/lib/Promise/functions.php
@@ -113,12 +113,11 @@ function resolve($value): Promise
 {
     if ($value instanceof Promise) {
         return $value->then();
-    } else {
-        $promise = new Promise();
-        $promise->fulfill($value);
-
-        return $promise;
     }
+    $promise = new Promise();
+    $promise->fulfill($value);
+
+    return $promise;
 }
 
 /**

--- a/lib/coroutine.php
+++ b/lib/coroutine.php
@@ -85,10 +85,9 @@ function coroutine(callable $gen): Promise
                 // We need to break out of the loop, because $advanceGenerator
                 // will be called asynchronously when the promise has a result.
                 break;
-            } else {
-                // If the value was not a promise, we'll just let it pass through.
-                $generator->send($yieldedValue);
             }
+            // If the value was not a promise, we'll just let it pass through.
+            $generator->send($yieldedValue);
         }
 
         // If the generator is at the end, and we didn't run into an exception,


### PR DESCRIPTION
php-cs-fixer 3.93 (among many other things) added a fixer for `no-useless-else`

https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/9340

Let php-cs-fixer get rid of these useless `else` blocks.

No change to behaviour, so no need to release.