### PR TITLE
[5.1] chore: fixup php-cs-fixer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.17.1||3.94.0",
+        "friendsofphp/php-cs-fixer": "~2.17.1||^3.95",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.6"
     },


### PR DESCRIPTION
[5.1] Somehow I got php-cs-fixer exactly "3.94.0" in composer, when resolving conflicts.
This fixes it so that any version from the current minor release 3.95 up is allowed.
