### PR TITLE
chore: bump php-cs-fixer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.94",
+        "friendsofphp/php-cs-fixer": "^3.95",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",


### PR DESCRIPTION
Similar to #149 [5.1]

I might as well do this to master laso, so that I don't confuse myself wondering why [5.1] has cs-fixer 3.95 specified.