### PR TITLE
[5.1] fix: remove duplicate code from Promise.php and prepare release 5.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ChangeLog
 =========
 
+5.1.8 (2026-04-27)
+------------------
+
+* #147 chore: adjust code for cs-fixer no-useless-else (@phil-davis)
+* #151 fix: remove duplicate code from Promise.php and release (@phil-davis)
+* various bumps to versions of tools and actions in CI (@phil-davis)
+
 5.1.7 (2024-08-27)
 ------------------
 

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -186,9 +186,6 @@ class Promise
             return $this->value;
         }
         // If we got here, it means that the asynchronous operation
-        // errored. Therefore we need to throw an exception.
-        throw $this->value;
-        // If we got here, it means that the asynchronous operation
         // errored. Therefore, we need to throw an exception.
         if ($this->value instanceof \Throwable) {
             throw $this->value;

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '5.1.7';
+    public const VERSION = '5.1.8';
 }


### PR DESCRIPTION
An automated code fix had put some lines of unneeded and almost-duplicated code into Promise.php. That was in PR #147 
That is removed here, and changelog and version bump for release as 5.1.8.

This is likely to be the last time that the 5.1 release series is maintained. It still has minimum HP 7.1, which is very old!