### PR TITLE
chore: drop support for PHP 7.4 8.0 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3','8.4']
+        php-versions: ['8.3','8.4']
         coverage: ['pcov']
         code-style: ['no']
         code-analysis: ['no']
         rector-check: ['no']
         include:
-          - php-versions: '7.4'
-            coverage: 'none'
+          - php-versions: '8.2'
+            coverage: 'pcov'
             code-style: 'yes'
             code-analysis: 'yes'
             rector-check: 'no'

--- a/README.md
+++ b/README.md
@@ -17,20 +17,19 @@ Installation
 
 Make sure you have [composer][3] installed, and then run:
 
-    composer require sabre/event "^5.0"
+    composer require sabre/event "^6.1"
 
-This package requires PHP 7.1.
+This package requires PHP 8.2.
 
 Build status
 ------------
+![Build Status](https://github.com/sabre-io/event/actions/workflows/ci.yml/badge.svg)
 
-| branch | status |
-| ------ | ------ |
-| master | [![Build Status](https://travis-ci.org/sabre-io/event.svg?branch=master)](https://travis-ci.org/sabre-io/event) |
-| 3.0    | [![Build Status](https://travis-ci.org/sabre-io/event.svg?branch=3.0)](https://travis-ci.org/sabre-io/event) |
-| 2.0    | [![Build Status](https://travis-ci.org/sabre-io/event.svg?branch=2.0)](https://travis-ci.org/sabre-io/event) |
-| 1.0    | [![Build Status](https://travis-ci.org/sabre-io/event.svg?branch=1.0)](https://travis-ci.org/sabre-io/event) |
-| php53  | [![Build Status](https://travis-ci.org/sabre-io/event.svg?branch=php53)](https://travis-ci.org/sabre-io/event) |
+| release | minimum PHP version |
+|---------|---------------------|
+| master  | PHP 8.2             |
+| 6.0     | PHP 7.4             |
+| 5.1     | PHP 7.1             |
 
 
 Questions?
@@ -45,4 +44,4 @@ This library is being developed by [fruux](https://fruux.com/). Drop us a line f
 
 [1]: https://sabre.io/event/
 [3]: https://getcomposer.org/
-[5]: https://github.com/fruux/sabre-event/issues/
+[5]: https://github.com/sabre-io/event/issues/

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "homepage": "http://sabre.io/event/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^8.2"
     },
     "authors": [
         {
@@ -52,7 +52,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.4",
         "phpunit/phpunit": "^9.6",
-        "rector/rector": "^2.3"
+        "rector/rector": "^2.4"
     },
     "scripts": {
         "phpstan": [
@@ -79,6 +79,9 @@
     "config": {
         "allow-plugins": {
             "phpstan/extension-installer": true
+        },
+        "platform": {
+            "php": "8.2"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.4",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^10.5",
         "rector/rector": "^2.4"
     },
     "scripts": {

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -57,8 +57,8 @@ class Promise
     {
         if (is_callable($executor)) {
             $executor(
-                [$this, 'fulfill'],
-                [$this, 'reject']
+                $this->fulfill(...),
+                $this->reject(...)
             );
         }
     }
@@ -241,7 +241,7 @@ class Promise
                         // returned a promise, we only fulfill or reject the
                         // chained promise once that promise has also been
                         // resolved.
-                        $result->then([$subPromise, 'fulfill'], [$subPromise, 'reject']);
+                        $result->then($subPromise->fulfill(...), $subPromise->reject(...));
                     } else {
                         // If the callback returned any other value, we
                         // immediately fulfill the chained promise.

--- a/lib/WildcardEmitterTrait.php
+++ b/lib/WildcardEmitterTrait.php
@@ -136,7 +136,12 @@ trait WildcardEmitterTrait
 
             foreach ($this->wildcardListeners as $wcEvent => $wcListeners) {
                 // Wildcard match
-                if (\substr($eventName, 0, \strlen($wcEvent)) === $wcEvent) {
+                // Rector adds the "string" cast because $wcEvent could be a
+                // "numeric string" like "456". And in PHP the array key is
+                // int 456, and so the cast might be needed here.
+                // But phpstan thinks that the cast is useless.
+                // @phpstan-ignore cast.useless
+                if (str_starts_with($eventName, (string) $wcEvent)) {
                     foreach ($wcListeners as $listener) {
                         $listenersPriority[] = $listener[0];
                         $listeners[] = $listener[1];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,5 @@
 parameters:
   level: 9
-  phpVersion: 80200 # PHP 8.2.0
   ignoreErrors:
   -
     message: "#^If condition is always true.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 parameters:
   level: 9
-  phpVersion: 70430 # PHP 7.4.30
+  phpVersion: 80200 # PHP 8.2.0
   ignoreErrors:
   -
     message: "#^If condition is always true.$#"

--- a/rector.php
+++ b/rector.php
@@ -11,7 +11,7 @@ return RectorConfig::configure()
         __DIR__.'/tests',
     ])
     // uncomment to reach your current PHP version
-    ->withPhpSets(false, false, false, false, true)
+    ->withPhpSets(false, true)
     ->withTypeCoverageLevel(0)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0);


### PR DESCRIPTION
This is planned to be released as 6.1.0

The existing 6.0 release series will be kept, and can have patch releases in future, if needed, for PHP 7.4 support.

Link explaining why casting of a "string" array key to string is often still needed:
https://phpstan.org/blog/why-array-string-keys-are-not-type-safe
