### PR TITLE
test: add failure options to phpunit10 settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ composer.lock
 
 #development stuff
 tests/cov
+tests/.phpunit.cache
 tests/.phpunit.result.cache
 .php_cs.cache
 .php-cs-fixer.cache

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="../vendor/autoload.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage includeUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">../lib/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="../vendor/autoload.php" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="sabre-event">
       <directory>.</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">../lib/</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
set options failOnRisky and failOnWarning so that CI will fail in these cases. That is new phpunit behavior that needs to be set, otherwise the test suite can exit with success even though there are "risky" tests or warnings.

Similar to https://github.com/sabre-io/xml/pull/328

Test settings only, nothing to release.
