### PR TITLE
test: migrate to phpunit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.4",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^11.5",
         "rector/rector": "^2.4"
     },
     "scripts": {

--- a/tests/Event/EmitterTest.php
+++ b/tests/Event/EmitterTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sabre\Event;
 
+use PHPUnit\Framework\Attributes\Depends;
+
 class EmitterTest extends \PHPUnit\Framework\TestCase
 {
     public function testInit(): void
@@ -24,9 +26,7 @@ class EmitterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals([$callback2, $callback1], $ee->listeners('foo'));
     }
 
-    /**
-     * @depends testInit
-     */
+    #[Depends('testInit')]
     public function testHandleEvent(): void
     {
         $argResult = null;
@@ -43,9 +43,7 @@ class EmitterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('bar', $argResult);
     }
 
-    /**
-     * @depends testHandleEvent
-     */
+    #[Depends('testHandleEvent')]
     public function testCancelEvent(): void
     {
         $argResult = 0;
@@ -67,9 +65,7 @@ class EmitterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals(1, $argResult);
     }
 
-    /**
-     * @depends testCancelEvent
-     */
+    #[Depends('testCancelEvent')]
     public function testPriority(): void
     {
         $argResult = 0;
@@ -93,9 +89,7 @@ class EmitterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals(2, $argResult);
     }
 
-    /**
-     * @depends testPriority
-     */
+    #[Depends('testPriority')]
     public function testPriority2(): void
     {
         $result = [];
@@ -249,9 +243,7 @@ class EmitterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals(1, $result);
     }
 
-    /**
-     * @depends testCancelEvent
-     */
+    #[Depends('testCancelEvent')]
     public function testPriorityOnce(): void
     {
         $argResult = 0;

--- a/tests/Event/WildcardEmitterTest.php
+++ b/tests/Event/WildcardEmitterTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sabre\Event;
 
+use PHPUnit\Framework\Attributes\Depends;
+
 class WildcardEmitterTest extends \PHPUnit\Framework\TestCase
 {
     public function testInit(): void
@@ -37,9 +39,7 @@ class WildcardEmitterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals([$callback1], $ee->listeners('foo:baz'));
     }
 
-    /**
-     * @depends testInit
-     */
+    #[Depends('testInit')]
     public function testHandleEvent(): void
     {
         $argResult = null;
@@ -56,9 +56,7 @@ class WildcardEmitterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('bar', $argResult);
     }
 
-    /**
-     * @depends testHandleEvent
-     */
+    #[Depends('testHandleEvent')]
     public function testCancelEvent(): void
     {
         $argResult = 0;
@@ -86,9 +84,7 @@ class WildcardEmitterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals(2, $argResult);
     }
 
-    /**
-     * @depends testCancelEvent
-     */
+    #[Depends('testCancelEvent')]
     public function testPriority(): void
     {
         $argResult = 0;
@@ -112,9 +108,7 @@ class WildcardEmitterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals(2, $argResult);
     }
 
-    /**
-     * @depends testPriority
-     */
+    #[Depends('testPriority')]
     public function testPriority2(): void
     {
         $result = [];
@@ -289,9 +283,7 @@ class WildcardEmitterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals(1, $result);
     }
 
-    /**
-     * @depends testCancelEvent
-     */
+    #[Depends('testCancelEvent')]
     public function testPriorityOnce(): void
     {
         $argResult = 0;


### PR DESCRIPTION
convert test annotations to PHP attributes

The XML schema is the same for PHPunit 10 and 11,
so that does not need to be migrated.