### PR TITLE
ci: add rector DataProvider rules

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
+use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockFromDataProviderRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -12,6 +14,10 @@ return RectorConfig::configure()
     ])
     // uncomment to reach your current PHP version
     ->withPhpSets(false, true)
+    ->withRules([
+        AddParamArrayDocblockFromDataProviderRector::class,
+        DataProviderAnnotationToAttributeRector::class,
+    ])
     ->withTypeCoverageLevel(0)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0);


### PR DESCRIPTION
to be consistent across all sabre-io repos.